### PR TITLE
Esp compatiblility

### DIFF
--- a/src/SmoothThermistor.cpp
+++ b/src/SmoothThermistor.cpp
@@ -49,8 +49,9 @@ SmoothThermistor::SmoothThermistor(uint8_t analogPin, uint16_t adcSize, uint32_t
 }
 
 void SmoothThermistor::useAREF(bool aref) {
-
+#IFNDEF ESP32
     analogReference(aref? EXTERNAL: DEFAULT);
+#ENDIF
 }
 
 float SmoothThermistor::temperature(void) {

--- a/src/SmoothThermistor.cpp
+++ b/src/SmoothThermistor.cpp
@@ -49,9 +49,11 @@ SmoothThermistor::SmoothThermistor(uint8_t analogPin, uint16_t adcSize, uint32_t
 }
 
 void SmoothThermistor::useAREF(bool aref) {
-#IFNDEF ESP32
+  
+#IF !defined(ESP32) || !defined(ESP8266)
     analogReference(aref? EXTERNAL: DEFAULT);
 #ENDIF
+  
 }
 
 float SmoothThermistor::temperature(void) {


### PR DESCRIPTION
Allows use of esp32 and esp8266 which doesn't have an analogReference