### PR TITLE
exclude analogReference for ESP32 AND ESP8266

### DIFF
--- a/src/SmoothThermistor.cpp
+++ b/src/SmoothThermistor.cpp
@@ -50,9 +50,9 @@ SmoothThermistor::SmoothThermistor(uint8_t analogPin, uint16_t adcSize, uint32_t
 
 void SmoothThermistor::useAREF(bool aref) {
   
-#IF !defined(ESP32) && !defined(ESP8266)
+#if !defined(ESP32) && !defined(ESP8266)
     analogReference(aref? EXTERNAL: DEFAULT);
-#ENDIF
+#endif
   
 }
 

--- a/src/SmoothThermistor.cpp
+++ b/src/SmoothThermistor.cpp
@@ -50,7 +50,7 @@ SmoothThermistor::SmoothThermistor(uint8_t analogPin, uint16_t adcSize, uint32_t
 
 void SmoothThermistor::useAREF(bool aref) {
   
-#IF !defined(ESP32) || !defined(ESP8266)
+#IF !defined(ESP32) && !defined(ESP8266)
     analogReference(aref? EXTERNAL: DEFAULT);
 #ENDIF
   


### PR DESCRIPTION
By performing an OR comparison, it would actually ONLY use analogReference for ESP32 OR ESP8266 and exclude it for regular boards. which is the oposite of what's desired.